### PR TITLE
Disable bug reports if homeserver is not synod.im

### DIFF
--- a/library/ui-strings/src/main/res/values-de/strings.xml
+++ b/library/ui-strings/src/main/res/values-de/strings.xml
@@ -1057,7 +1057,8 @@
     <string name="login_splash_submit">Los geht\'s</string>
     <string name="login_server_title">Wähle einen Server</string>
     <string name="login_server_text">Genau wie bei E-Mails haben Accounts ein Zuhause, auch wenn du mit jedem kommunizieren kannst</string>
-    <string name="login_server_matrix_org_text">Tausche dich aus - mit dem sicheren Messenger im kirchlichen Bereich</string>
+    <string name="login_server_matrix_org_text">Folge Millionen Anderen kostenlos auf dem größten öffentlichen Server</string>
+    <string name="login_server_synod_im_text">Tausche dich aus - mit dem sicheren Messenger im kirchlichen Bereich</string>
     <string name="login_server_modular_text">Premium-Hosting für Organisationen</string>
     <string name="login_server_modular_learn_more">Mehr erfahren</string>
     <string name="login_server_other_title">Andere</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2126,7 +2126,8 @@
 
     <string name="login_server_title">Select a server</string>
     <string name="login_server_text">Just like email, accounts have one home, although you can talk to anyone</string>
-    <string name="login_server_matrix_org_text">Communicate - using the secure messenger for congregations</string>
+    <string name="login_server_matrix_org_text">Join millions for free on the largest public server</string>
+    <string name="login_server_synod_im_text">Communicate - using the secure messenger for congregations</string>
     <string name="login_server_modular_text">Premium hosting for organisations</string>
     <string name="login_server_modular_learn_more">Learn more</string>
     <string name="login_server_other_title">Other</string>

--- a/vector-config/src/main/res/values/config.xml
+++ b/vector-config/src/main/res/values/config.xml
@@ -4,7 +4,8 @@
     <!-- "app_name" is now defined in build.gradle -->
 
     <!-- server urls -->
-    <string name="matrix_org_server_url" translatable="false">https://synod.im</string>
+    <string name="matrix_org_server_url" translatable="false">https://matrix.org</string>
+    <string name="synod_im_server_url" translatable="false">https://synod.im</string>
 
     <!-- Rageshake configuration -->
     <string name="bug_report_url" translatable="false">https://bugs.synod.im</string>

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -613,6 +613,16 @@ class HomeActivity :
     override fun handlePrepareMenu(menu: Menu) {
         menu.findItem(R.id.menu_home_init_sync_legacy).isVisible = vectorPreferences.developerMode()
         menu.findItem(R.id.menu_home_init_sync_optimized).isVisible = vectorPreferences.developerMode()
+        // Changed for Synod.im: Disable bug reporting when on third party home server.
+        // Rage shake is still possible to keep the code changes minimal.
+        if (activeSessionHolder.hasActiveSession()) {
+            val homeServerUrlBase = activeSessionHolder.getActiveSession().sessionParams.homeServerUrlBase;
+            val defaultHomeServerUrl = getString(im.vector.app.config.R.string.synod_im_server_url)
+            if (homeServerUrlBase != defaultHomeServerUrl) {
+                menu.findItem(R.id.menu_home_report_bug).isVisible = false
+                menu.findItem(R.id.menu_home_suggestion).isVisible = false
+            }
+        }
     }
 
     override fun handleMenuItemSelected(item: MenuItem): Boolean {

--- a/vector/src/main/java/im/vector/app/features/homeserver/ServerUrlsRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/homeserver/ServerUrlsRepository.kt
@@ -80,5 +80,5 @@ class ServerUrlsRepository @Inject constructor(
     /**
      * Return default homeserver url from resources.
      */
-    private fun getDefaultHomeServerUrl() = stringProvider.getString(im.vector.app.config.R.string.matrix_org_server_url)
+    private fun getDefaultHomeServerUrl() = stringProvider.getString(im.vector.app.config.R.string.synod_im_server_url)
 }

--- a/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
@@ -247,6 +247,7 @@ open class LoginActivity : VectorBaseActivity<ActivityLoginBinding>(), UnlockedA
     private fun onServerSelectionDone(loginViewEvents: LoginViewEvents.OnServerSelectionDone) {
         when (loginViewEvents.serverType) {
             ServerType.MatrixOrg -> Unit // In this case, we wait for the login flow
+            ServerType.SynodIm -> Unit // In this case, we wait for the login flow
             ServerType.EMS,
             ServerType.Other -> addFragmentToBackstack(
                     views.loginFragmentContainer,

--- a/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
@@ -171,11 +171,15 @@ class LoginFragment :
 
             when (state.serverType) {
                 ServerType.MatrixOrg -> {
-                    // Changed for Synod.im: Hide matrix.org icon.
-                    views.loginServerIcon.isVisible = false
+                    views.loginServerIcon.isVisible = true
                     views.loginServerIcon.setImageResource(R.drawable.ic_logo_matrix_org)
                     views.loginTitle.text = getString(resId, state.homeServerUrlFromUser.toReducedUrl())
                     views.loginNotice.text = getString(CommonStrings.login_server_matrix_org_text)
+                }
+                ServerType.SynodIm -> {
+                    views.loginServerIcon.isVisible = false
+                    views.loginTitle.text = getString(resId, state.homeServerUrlFromUser.toReducedUrl())
+                    views.loginNotice.text = getString(CommonStrings.login_server_synod_im_text)
                 }
                 ServerType.EMS -> {
                     views.loginServerIcon.isVisible = true
@@ -259,7 +263,7 @@ class LoginFragment :
 
     override fun updateWithState(state: LoginViewState) {
         isSignupMode = state.signMode == SignMode.SignUp
-        isNumericOnlyUserIdForbidden = state.serverType == ServerType.MatrixOrg
+        isNumericOnlyUserIdForbidden = state.serverType == ServerType.MatrixOrg || state.serverType == ServerType.SynodIm
 
         setupUi(state)
         setupAutoFill(state)

--- a/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
@@ -47,10 +47,14 @@ class LoginSignUpSignInSelectionFragment :
         when (state.serverType) {
             ServerType.MatrixOrg -> {
                 views.loginSignupSigninServerIcon.setImageResource(R.drawable.ic_logo_matrix_org)
-                // Changed for Synod.im: Hide matrix.org icon.
-                views.loginSignupSigninServerIcon.isVisible = false
+                views.loginSignupSigninServerIcon.isVisible = true
                 views.loginSignupSigninTitle.text = getString(CommonStrings.login_connect_to, state.homeServerUrlFromUser.toReducedUrl())
                 views.loginSignupSigninText.text = getString(CommonStrings.login_server_matrix_org_text)
+            }
+            ServerType.SynodIm -> {
+                views.loginSignupSigninServerIcon.isVisible = false
+                views.loginSignupSigninTitle.text = getString(CommonStrings.login_connect_to, state.homeServerUrlFromUser.toReducedUrl())
+                views.loginSignupSigninText.text = getString(CommonStrings.login_server_synod_im_text)
             }
             ServerType.EMS -> {
                 views.loginSignupSigninServerIcon.setImageResource(R.drawable.ic_logo_element_matrix_services)

--- a/vector/src/main/java/im/vector/app/features/login/LoginSplashFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginSplashFragment.kt
@@ -75,7 +75,7 @@ class LoginSplashFragment :
             loginViewModel.handle(LoginAction.OnGetStarted(resetLoginConfig = false))
         } else {
             // Synod.im: skip server selection
-            loginViewModel.handle(LoginAction.UpdateHomeServer(getString(im.vector.app.config.R.string.matrix_org_server_url).ensureTrailingSlash()))
+            loginViewModel.handle(LoginAction.UpdateHomeServer(getString(im.vector.app.config.R.string.synod_im_server_url).ensureTrailingSlash()))
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -82,6 +82,7 @@ class LoginViewModel @AssistedInject constructor(
     private var currentHomeServerConnectionConfig: HomeServerConnectionConfig? = null
 
     private val matrixOrgUrl = stringProvider.getString(im.vector.app.config.R.string.matrix_org_server_url).ensureTrailingSlash()
+    private val synodImUrl = stringProvider.getString(im.vector.app.config.R.string.synod_im_server_url).ensureTrailingSlash()
 
     val currentThreePid: String?
         get() = registrationWizard?.getCurrentThreePid()
@@ -441,6 +442,9 @@ class LoginViewModel @AssistedInject constructor(
             ServerType.MatrixOrg ->
                 // Request login flow here
                 handle(LoginAction.UpdateHomeServer(matrixOrgUrl))
+            ServerType.SynodIm ->
+                // Request login flow here
+                handle(LoginAction.UpdateHomeServer(synodImUrl))
             ServerType.EMS,
             ServerType.Other -> _viewEvents.post(LoginViewEvents.OnServerSelectionDone(action.serverType))
         }
@@ -780,6 +784,8 @@ class LoginViewModel @AssistedInject constructor(
                         // It is also useful to set the value again in the case of a certificate error on matrix.org
                         serverType = if (homeServerConnectionConfig.homeServerUri.toString() == matrixOrgUrl) {
                             ServerType.MatrixOrg
+                        } else if (homeServerConnectionConfig.homeServerUri.toString() == synodImUrl) {
+                            ServerType.SynodIm
                         } else {
                             serverTypeOverride ?: serverType
                         }
@@ -793,8 +799,8 @@ class LoginViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             asyncHomeServerLoginFlowRequest = Uninitialized,
-                            // If we were trying to retrieve matrix.org login flow, also reset the serverType
-                            serverType = if (serverType == ServerType.MatrixOrg) ServerType.Unknown else serverType
+                            // If we were trying to retrieve matrix.org or synod.im login flow, also reset the serverType
+                            serverType = if (serverType == ServerType.MatrixOrg || serverType == ServerType.SynodIm) ServerType.Unknown else serverType
                     )
                 }
                 null

--- a/vector/src/main/java/im/vector/app/features/login/ServerType.kt
+++ b/vector/src/main/java/im/vector/app/features/login/ServerType.kt
@@ -11,5 +11,6 @@ enum class ServerType {
     Unknown,
     MatrixOrg,
     EMS,
-    Other
+    Other,
+    SynodIm
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -8,6 +8,8 @@
 package im.vector.app.features.onboarding
 
 import android.content.Context
+import android.content.res.Resources
+import androidx.core.os.ConfigurationCompat
 import com.airbnb.mvrx.MavericksViewModelFactory
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -115,7 +117,8 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private val matrixOrgUrl = stringProvider.getString(im.vector.app.config.R.string.matrix_org_server_url).ensureTrailingSlash()
-    private val defaultHomeserverUrl = mdmService.getData(MdmData.DefaultHomeserverUrl, matrixOrgUrl)
+    private val synodImUrl = stringProvider.getString(im.vector.app.config.R.string.synod_im_server_url).ensureTrailingSlash()
+    private val defaultHomeserverUrl = mdmService.getData(MdmData.DefaultHomeserverUrl, synodImUrl)
 
     private val registrationWizard: RegistrationWizard
         get() = authenticationService.getRegistrationWizard()
@@ -233,7 +236,7 @@ class OnboardingViewModel @AssistedInject constructor(
     private fun handleSplashAction(action: OnboardingAction.SplashAction) {
         setState { copy(onboardingFlow = action.onboardingFlow) }
         // Changed for Synod.im: Skip server selection
-        handle(OnboardingAction.HomeServerChange.SelectHomeServer(matrixOrgUrl))
+        handle(OnboardingAction.HomeServerChange.SelectHomeServer(synodImUrl))
         // Previous code: (would show "Server Selection Screen")
         // continueToPageAfterSplash(action.onboardingFlow)
     }
@@ -473,6 +476,9 @@ class OnboardingViewModel @AssistedInject constructor(
             ServerType.MatrixOrg ->
                 // Request login flow here
                 handle(OnboardingAction.HomeServerChange.SelectHomeServer(matrixOrgUrl))
+            ServerType.SynodIm ->
+                // Request login flow here
+                handle(OnboardingAction.HomeServerChange.SelectHomeServer(synodImUrl))
             ServerType.EMS,
             ServerType.Other -> _viewEvents.post(OnboardingViewEvents.OnServerSelectionDone(action.serverType))
         }
@@ -822,6 +828,8 @@ class OnboardingViewModel @AssistedInject constructor(
     private fun OnboardingViewState.alignServerTypeAfterSubmission(config: HomeServerConnectionConfig, serverTypeOverride: ServerType?): ServerType {
         return if (config.homeServerUri.toString() == matrixOrgUrl) {
             ServerType.MatrixOrg
+        } else if (config.homeServerUri.toString() == synodImUrl) {
+            ServerType.SynodIm
         } else {
             serverTypeOverride ?: serverType
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/RegistrationActionHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/RegistrationActionHandler.kt
@@ -30,6 +30,7 @@ class RegistrationActionHandler @Inject constructor(
 ) {
 
     private val matrixOrgUrl = stringProvider.getString(im.vector.app.config.R.string.matrix_org_server_url).ensureTrailingSlash()
+    private val synodImUrl = stringProvider.getString(im.vector.app.config.R.string.synod_im_server_url).ensureTrailingSlash()
 
     suspend fun processAction(state: SelectedHomeserverState, action: RegisterAction): Result {
         val result = registrationWizardActionDelegate.executeAction(action)
@@ -66,7 +67,7 @@ class RegistrationActionHandler @Inject constructor(
 
     private fun findNextStage(state: SelectedHomeserverState, flowResult: FlowResult): Result {
         val orderedResult = when {
-            state.hasSelectedMatrixOrg() && vectorFeatures.isOnboardingCombinedRegisterEnabled() -> flowResult.copy(
+            state.hasSelectedMatrixOrgOrSynodIm() && vectorFeatures.isOnboardingCombinedRegisterEnabled() -> flowResult.copy(
                     missingStages = flowResult.missingStages.sortedWith(MatrixOrgRegistrationStagesComparator())
             )
             else -> flowResult
@@ -80,7 +81,7 @@ class RegistrationActionHandler @Inject constructor(
 
     private suspend fun FlowResult.registrationShouldFallback() = vectorOverrides.forceLoginFallback.first() || missingStages.any { !it.isSupported() }
 
-    private fun SelectedHomeserverState.hasSelectedMatrixOrg() = userFacingUrl == matrixOrgUrl
+    private fun SelectedHomeserverState.hasSelectedMatrixOrgOrSynodIm() = userFacingUrl == matrixOrgUrl || userFacingUrl == synodImUrl
 
     sealed interface Result {
         data class RegistrationComplete(val session: Session) : Result

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
@@ -280,4 +280,5 @@ class FtueAuthCombinedRegisterFragment :
 
     private fun OnboardingViewState.isNumericOnlyUserIdForbidden() =
             selectedHomeserver.userFacingUrl == getString(im.vector.app.config.R.string.matrix_org_server_url)
+                    || selectedHomeserver.userFacingUrl == getString(im.vector.app.config.R.string.synod_im_server_url)
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -186,11 +186,15 @@ class FtueAuthLoginFragment :
 
             when (state.serverType) {
                 ServerType.MatrixOrg -> {
-                    // Changed for Synod.im: Hide matrix.org icon.
-                    views.loginServerIcon.isVisible = false
+                    views.loginServerIcon.isVisible = true
                     views.loginServerIcon.setImageResource(R.drawable.ic_logo_matrix_org)
                     views.loginTitle.text = getString(resId, state.selectedHomeserver.userFacingUrl.toReducedUrl())
                     views.loginNotice.text = getString(CommonStrings.login_server_matrix_org_text)
+                }
+                ServerType.SynodIm -> {
+                    views.loginServerIcon.isVisible = false
+                    views.loginTitle.text = getString(resId, state.selectedHomeserver.userFacingUrl.toReducedUrl())
+                    views.loginNotice.text = getString(CommonStrings.login_server_synod_im_text)
                 }
                 ServerType.EMS -> {
                     views.loginServerIcon.isVisible = true
@@ -293,7 +297,7 @@ class FtueAuthLoginFragment :
 
     override fun updateWithState(state: OnboardingViewState) {
         isSignupMode = state.signMode == SignMode.SignUp
-        isNumericOnlyUserIdForbidden = state.serverType == ServerType.MatrixOrg
+        isNumericOnlyUserIdForbidden = state.serverType == ServerType.MatrixOrg || state.serverType == ServerType.SynodIm
 
         setupUi(state)
         setupAutoFill(state)

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
@@ -55,10 +55,14 @@ class FtueAuthSignUpSignInSelectionFragment :
     private fun render(state: OnboardingViewState) {
         when (state.serverType) {
             ServerType.MatrixOrg -> renderServerInformation(
-                    // Changed for Synod.im: Hide matrix.org icon.
-                    icon = null, // R.drawable.ic_logo_matrix_org,
+                    icon = R.drawable.ic_logo_matrix_org,
                     title = getString(CommonStrings.login_connect_to, state.selectedHomeserver.userFacingUrl.toReducedUrl()),
                     subtitle = getString(CommonStrings.login_server_matrix_org_text)
+            )
+            ServerType.SynodIm -> renderServerInformation(
+                    icon = null,
+                    title = getString(CommonStrings.login_connect_to, state.selectedHomeserver.userFacingUrl.toReducedUrl()),
+                    subtitle = getString(CommonStrings.login_server_synod_im_text)
             )
             ServerType.EMS -> renderServerInformation(
                     icon = R.drawable.ic_logo_element_matrix_services,

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -299,6 +299,7 @@ class FtueAuthVariant(
     private fun onServerSelectionDone(onboardingViewEvents: OnboardingViewEvents.OnServerSelectionDone) {
         when (onboardingViewEvents.serverType) {
             ServerType.MatrixOrg -> Unit // In this case, we wait for the login flow
+            ServerType.SynodIm -> Unit // In this case, we wait for the login flow
             ServerType.EMS,
             ServerType.Other -> activity.addFragmentToBackstack(
                     views.loginFragmentContainer,


### PR DESCRIPTION
This also adds synod.im string keys, enums and variable names instead of re-using those for matrix.org.